### PR TITLE
default to 0 if values are not set yet

### DIFF
--- a/src/app-components/allocation-tables/index.js
+++ b/src/app-components/allocation-tables/index.js
@@ -212,10 +212,9 @@ const GroupAllocationTable = connect(
         office={officeActive}
         doModalOpen={doModalOpen}
         // Largest target or allocated size among all offices
-        maxBulletSize={items.reduce(
-          (a, b) => Math.max(a, b.target, b.allocated),
-          0
-        )}
+        maxBulletSize={
+          items.reduce((a, b) => Math.max(a, b.target, b.allocated), 0) || 0
+        }
       />
     );
   }


### PR DESCRIPTION
error did not present when group had positions, but no occupants.  When one occupant was added to any group, error caused white screen (console errors).