### PR TITLE
Feature/fix tooltips after vite conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workforce-ui",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workforce-ui",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@headlessui/react": "^1.7.18",
         "@heroicons/react": "^1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workforce-ui",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workforce-ui",
-      "version": "0.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@headlessui/react": "^1.7.18",
         "@heroicons/react": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workforce-ui",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/app-components/allocation-tables/index.js
+++ b/src/app-components/allocation-tables/index.js
@@ -225,9 +225,10 @@ const AllocationTable = ({
                           `${t.office_symbol}.admin`,
                         ]}
                       >
-                        <ReactTooltip />
+                        <ReactTooltip id="tt" />
                         <button
-                          data-tip="Edit Group"
+                          data-tooltip-content="Edit Group"
+                          data-tooltip-id="tt"
                           onClick={(e) => {
                             doModalOpen(EditGroupModal, { group: t });
                           }}
@@ -236,7 +237,8 @@ const AllocationTable = ({
                           <PencilAltIcon className="w-6 h-6" />
                         </button>
                         <button
-                          data-tip="Verify Group"
+                          data-tooltip-content="Verify Group"
+                          data-tooltip-id="tt"
                           onClick={(e) => {
                             doModalOpen(VerifyGroupModal, { group: t });
                           }}

--- a/src/app-components/position-tables/EditPositionModal.js
+++ b/src/app-components/position-tables/EditPositionModal.js
@@ -201,7 +201,8 @@ const EditPositionModal = connect(
                     <span className="text-gray-600">
                       <span className="text-lg text-red-700 mr-1 ">*</span>
                       <span
-                        data-tip="For career ladder positions like 7/9/11 use 11"
+                        data-tooltip-id="tt"
+                        data-tooltip-content="For career ladder positions like 7/9/11 use 11"
                         className="border-b-2 border-dashed border-gray-400"
                       >
                         Target Grade

--- a/src/app-components/position-tables/index.js
+++ b/src/app-components/position-tables/index.js
@@ -24,7 +24,8 @@ const CredentialPill = ({ cred }) => {
 
   return (
     <div
-      data-tip={cred.name}
+      data-tooltip-id="tt"
+      data-tooltip-content={cred.name}
       className="mr-1 px-1 text-xs rounded-xl border-gray-300 border-2 bg-gray-100 inline"
     >
       {displayAbbrev}
@@ -127,9 +128,10 @@ const PositionTable = connect(
                     >
                       <td className="p-2 whitespace-nowrap">
                         <div className="flex items-center">
-                          <ReactTooltip />
+                          <ReactTooltip id="tt" />
                           <div
-                            data-tip={
+                            data-tooltip-id="tt"
+                            data-tooltip-content={
                               isVacant ? 'Position Vacant' : 'Position Filled'
                             }
                             className={`rounded-full w-14 h-14 flex justify-around items-center ${
@@ -148,7 +150,8 @@ const PositionTable = connect(
                             {title}
                             {is_supervisor && (
                               <StarIcon
-                                data-tip="Supervisor"
+                                data-tooltip-id="tt"
+                                data-tooltip-content="Supervisor"
                                 className="w-4 inline ml-1 mb-1 text-yellow-400"
                               />
                             )}
@@ -168,22 +171,25 @@ const PositionTable = connect(
                             {current_occupancy &&
                               current_occupancy.service_start_date && (
                                 <span
-                                  data-tip={`Government Experience = ${experience_gov}`}
+                                  data-tooltip-id="tt"
+                                  data-tooltip-content={`Government Experience = ${experience_gov}`}
                                   className=" text-gray-400 font-light border-b-2 border-gray-200 border-dashed cursor-default"
                                 >
                                   Gov: {experience_gov}
                                 </span>
                               )}
                             {/* Position Experience */}
-                            {current_occupancy && current_occupancy.start_date && (
-                              <span
-                                data-tip={`Position Experience = ${experience_pos}`}
-                                className="text-gray-400 font-light border-b-2 border-gray-200 border-dashed cursor-default"
-                              >
-                                {' / '}
-                                Pos: {experience_pos}
-                              </span>
-                            )}
+                            {current_occupancy &&
+                              current_occupancy.start_date && (
+                                <span
+                                  data-tooltip-id="tt"
+                                  data-tooltip-content={`Position Experience = ${experience_pos}`}
+                                  className="text-gray-400 font-light border-b-2 border-gray-200 border-dashed cursor-default"
+                                >
+                                  {' / '}
+                                  Pos: {experience_pos}
+                                </span>
+                              )}
                           </div>
                         </div>
                       </td>
@@ -223,7 +229,8 @@ const PositionTable = connect(
                           >
                             <>
                               <button
-                                data-tip="Edit Position"
+                                data-tooltip-id="tt"
+                                data-tooltip-content="Edit Position"
                                 onClick={(e) => {
                                   doModalOpen(EditPositionModal, {
                                     position: t,
@@ -235,7 +242,8 @@ const PositionTable = connect(
                               </button>
 
                               <button
-                                data-tip="Edit Occupant"
+                                data-tooltip-id="tt"
+                                data-tooltip-content="Edit Occupant"
                                 onClick={(e) => {
                                   doModalOpen(EditOccupancyModal, {
                                     position: t,
@@ -247,7 +255,8 @@ const PositionTable = connect(
                               </button>
 
                               <button
-                                data-tip="Duplicate Position"
+                                data-tooltip-id="tt"
+                                data-tooltip-content="Duplicate Position"
                                 onClick={(e) => {
                                   doModalOpen(EditPositionModal, {
                                     position: {

--- a/src/app-components/wrapper/index.js
+++ b/src/app-components/wrapper/index.js
@@ -22,7 +22,8 @@ const Statistics = connect(
               <div className="text-gray-900">{isLoading ? '-' : employees}</div>
               <div className="mx-2 text-gray-300">/</div>
               <div
-                data-tip="Allocated Position"
+                data-tooltip-id="tt"
+                data-tooltip-content="Allocated Position"
                 className="text-gray-300 border-b-2 border-dashed cursor-default"
               >
                 {isLoading ? '-' : positions}
@@ -41,7 +42,8 @@ const Statistics = connect(
             </div>
             <div className="flex title-font font-medium sm:text-4xl text-3xl justify-center">
               <div
-                data-tip="All Positions - Includes Allocated and UnAllocated Positions"
+                data-tooltip-id="tt"
+                data-tooltip-content="All Positions - Includes Allocated and UnAllocated Positions"
                 className="text-green-500 border-b-2 border-dashed cursor-default"
               >
                 {isLoading ? '-' : target}

--- a/src/app-pages/admin/admin-requests/request-table.js
+++ b/src/app-pages/admin/admin-requests/request-table.js
@@ -85,9 +85,10 @@ const OfficeAdminRequestTable = connect(
                     <tr key={idx}>
                       <td className="p-2 whitespace-nowrap">
                         <div className="flex items-center">
-                          <ReactTooltip />
+                          <ReactTooltip id="tt" />
                           <div
-                            data-tip={
+                            data-tooltip-id="tt"
+                            data-tooltip-content={
                               isApproved
                                 ? 'Approved'
                                 : isDenied
@@ -172,7 +173,8 @@ const OfficeAdminRequestTable = connect(
                           >
                             <>
                               <button
-                                data-tip="Approve"
+                                data-tooltip-id="tt"
+                                data-tooltip-content="Approve"
                                 disabled={isApproved}
                                 onClick={(e) =>
                                   handleUpdateStatus(id, 'approve')
@@ -187,7 +189,8 @@ const OfficeAdminRequestTable = connect(
                               </button>
 
                               <button
-                                data-tip="Deny"
+                                data-tooltip-id="tt"
+                                data-tooltip-content="Deny"
                                 disabled={isDenied}
                                 onClick={(e) => {
                                   handleUpdateStatus(id, 'deny');


### PR DESCRIPTION
Newer version of react tooltips was used after vite conversion. Required changes to data element ids to properly function.
cc @jeffsuperglide 